### PR TITLE
Make cats awesome again

### DIFF
--- a/mumble-kitty.rb
+++ b/mumble-kitty.rb
@@ -1,69 +1,91 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
- 
-require "mumble-ruby"
-require 'rubygems'
-require 'librmpd'
-require 'thread'
- 
-class MumbleMPD
- 
-	def initialize 
-		@mpd = MPD.new("localhost", 6604)
- 
-		@cli = Mumble::Client.new("mumble.coding4coffee.org", "64738", "fluffy", "")
-	end
- 
-	def start
-		@cli.connect
-		sleep(1)
-		@cli.join_channel("katzenkörbchen")
-		sleep(1)
-		@cli.stream_raw_audio("/var/lib/mpd/tmp/kitty.fifo")
- 
-		@mpd.connect
 
-		begin
-			running = true
-			Thread.new do
-				sleep(2)
-				while running
-					12.times do
-						channels = @cli.channels.values
-						newChannel = channels[rand(channels.length)]
-						puts Time.new.ctime + ": " + newChannel.name
-						@cli.join_channel(newChannel)
-						5.times do
-							@mpd.play()
-							sleep(60)
-						end
-					end
-					if rand(2) > 0
-						puts Time.new.ctime + ": sleep in katzenkörbchen"
-						@cli.join_channel("katzenkörbchen")
-						24.times do
-							@mpd.play()
-							sleep(300)
-						end
-					else
-						puts Time.new.ctime + ": sleep"
-						sleep(7200)
-					end
-				end
-			end
-		rescue Interrupt => e
-		end
- 
-		begin
-			t = Thread.new do
-				gets
-			end
- 
-			t.join
-		rescue Interrupt => e
-		end
-	end
+require "librmpd"
+require "mumble-ruby"
+require "rubygems"
+require "thread"
+
+CONFIG = {
+  mpd: {
+    host: ENV["KITTY_MPD_HOST"] || "localhost",
+    port: (ENV["KITTY_MPD_PORT"] || "6604").to_i,
+    fifo: ENV["KITTY_MPD_FIFO"] || "/var/lib/mpd/tmp/kitty.fifo"
+  },
+  mumble: {
+    host: ENV["KITTY_MUMBLE_HOST"] || "mumble.coding4coffee.org",
+    port: (ENV["KITTY_MUMBLE_PORT"] || "64738").to_i,
+    username: ENV["KITTY_MUMBLE_USERNAME"] || "fluffy",
+    channel: ENV["KITTY_MUMBLE_CHANNEL"] || "katzenkörbchen"
+  }
+}
+
+class MumbleMPD
+
+  def initialize
+    @mpd = MPD.new(
+      CONFIG[:mpd][:host],
+      CONFIG[:mpd][:port]
+    )
+
+    @cli = Mumble::Client.new(
+      CONFIG[:mumble][:host],
+      CONFIG[:mumble][:port],
+      CONFIG[:mumble][:username],
+      ""
+    )
+  end
+
+  def start
+    @cli.connect
+    sleep(1)
+    @cli.join_channel(CONFIG[:mumble][:channel])
+    sleep(1)
+    @cli.stream_raw_audio(CONFIG[:mpd][:fifo])
+
+    @mpd.connect
+
+    begin
+      running = true
+      Thread.new do
+        sleep(2)
+        while running
+          12.times do
+            channels = @cli.channels.values
+            newChannel = channels[rand(channels.length)]
+            puts Time.new.ctime + ": " + newChannel.name
+            @cli.join_channel(newChannel)
+            5.times do
+              @mpd.play()
+              sleep(60)
+            end
+          end
+          if rand(2) > 0
+            puts Time.new.ctime + ": sleep in katzenkörbchen"
+            @cli.join_channel(CONFIG[:mumble][:channel])
+            24.times do
+              @mpd.play()
+              sleep(300)
+            end
+          else
+            puts Time.new.ctime + ": sleep"
+            sleep(7200)
+          end
+        end
+      end
+    rescue Interrupt => e
+    end
+
+    begin
+      t = Thread.new do
+        gets
+      end
+
+      t.join
+    rescue Interrupt => e
+    end
+  end
 end
- 
+
 client = MumbleMPD.new
 client.start

--- a/mumble-kitty.rb
+++ b/mumble-kitty.rb
@@ -7,6 +7,9 @@ require "rubygems"
 require "thread"
 
 CONFIG = {
+  general: {
+    triggers: (ENV["KITTY_TRIGGERS"] || "catnip,flausch,keks,minze").split(",")
+  },
   mpd: {
     host: ENV["KITTY_MPD_HOST"] || "localhost",
     port: (ENV["KITTY_MPD_PORT"] || "6604").to_i,
@@ -48,6 +51,14 @@ class MumbleMPD
     end
 
     @mpd.connect
+
+    @cli.on_text_message do |msg|
+      text = msg.message.downcase
+      if CONFIG[:general][:triggers].any? {|trigger| text.include?(trigger)}
+        puts "#{Time.new.ctime}: Received trigger message, following sender!"
+        @cli.join_channel(@cli.users[msg.actor].channel_id)
+      end
+    end
 
     begin
       running = true

--- a/mumble-kitty.rb
+++ b/mumble-kitty.rb
@@ -41,7 +41,11 @@ class MumbleMPD
     sleep(1)
     @cli.join_channel(CONFIG[:mumble][:channel])
     sleep(1)
-    @cli.stream_raw_audio(CONFIG[:mpd][:fifo])
+    if @cli.player and @cli.player.respond_to? :stream_named_pipe
+      @cli.player.stream_named_pipe(CONFIG[:mpd][:fifo])
+    else
+      @cli.stream_raw_audio(CONFIG[:mpd][:fifo])
+    end
 
     @mpd.connect
 
@@ -53,7 +57,7 @@ class MumbleMPD
           12.times do
             channels = @cli.channels.values
             newChannel = channels[rand(channels.length)]
-            puts Time.new.ctime + ": " + newChannel.name
+            puts "#{Time.new.ctime}: #{newChannel.name}"
             @cli.join_channel(newChannel)
             5.times do
               @mpd.play()
@@ -61,14 +65,14 @@ class MumbleMPD
             end
           end
           if rand(2) > 0
-            puts Time.new.ctime + ": sleep in katzenkörbchen"
+            puts "#{Time.new.ctime}: sleep in #{CONFIG[:mumble][:channel]}"
             @cli.join_channel(CONFIG[:mumble][:channel])
             24.times do
               @mpd.play()
               sleep(300)
             end
           else
-            puts Time.new.ctime + ": sleep"
+            puts "#{Time.new.ctime}: sleep"
             sleep(7200)
           end
         end


### PR DESCRIPTION
This 📦 improves the 🐱 by 💯🍪!

* 😼⌚️ The 🐱 is now supported by newer `mumble-ruby` versions, but the old one should still work. 
* 😸🔧 It's now possible to set some variables via 🌍 vars, which makes de-🐞ing easier. However, I've kept the old defaults.
* 😻🍪 If you send the 🐱 a 💌 containing one of the top secret 🔤, you'll have her jumping on your laps!

Also, I had to 🗑 the tabs and replace them by spaces. Since this is a :clown_face:-PR anyway, I think that's totally fine. 🙈 I hope this works without any environmental changes for very fast deploying.